### PR TITLE
ClothesMate-Refill

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2689,6 +2689,13 @@
 	contains = list(/obj/item/vending_refill/wardrobe/cargo_wardrobe)
 	crate_name = "cargo department supply crate"
 
+/datum/supply_pack/costumes_toys/wardrobes/clothesmate
+	name = "ClothesMate Wardrobe Supply Crate"
+	desc = "This crate contains a refill for the ClothesMate."
+	cost = 800 
+	contains = list(/obj/item/vending_refill/clothing)
+	crate_name = "clothesmate supply crate"
+
 /datum/supply_pack/costumes_toys/wardrobes/engineering
 	name = "Engineering Wardrobe Supply Crate"
 	desc = "This crate contains refills for the EngiDrobe and AtmosDrobe."


### PR DESCRIPTION

## About The Pull Request

ClothesMate Refill purchasable from cargo

## Why It's Good For The Game

Adds the ability for someone to order a ClothesMate Refill canister From cargo

## Changelog
:cl:
add: ClothesMate Refill canister for 800 credits from cargo
/:cl:

